### PR TITLE
Support Leiningen 2.7 managed dependencies

### DIFF
--- a/src/leinjacker/deps.clj
+++ b/src/leinjacker/deps.clj
@@ -3,14 +3,23 @@
   {:author "Daniel Solano Gómez"}
   (:use leinjacker.defconstrainedfn))
 
+(defn modifier?
+  "Returns a value that evaluates to true if the argument appears to
+  be a valid modifier key+value for a dependency."
+  [modifier-pair]
+  (and (= 2 (count modifier-pair))
+       (keyword? (first modifier-pair))))
+
 (defn dep-spec?
   "Returns a value that evaluates to true if the argument appears to be a valid
-  dependency specification."
+  dependency specification. Supports managed dependencies with or without modifiers."
   [dep]
-  (and (vector? dep)
-       (>= (count dep) 2)
-       (symbol? (first dep))
-       (string? (second dep))))
+  (when (vector? dep)
+    (let [[[dep-name version?] modifiers] (split-with (complement keyword?) dep)
+          modifier-pairs (partition-all 2 modifiers)]
+      (and (symbol? dep-name)
+           (or (string? version?) (nil? version?))
+           (every? modifier? modifier-pairs)))))
 
 (defn dep?
   "Returns a value that evaluates to true if the argument appears to be a valid

--- a/test/leinjacker/deps_test.clj
+++ b/test/leinjacker/deps_test.clj
@@ -11,6 +11,13 @@
   truthy     ['org.clojure/clojure "1.2.1"]
   truthy     ['vimclojure/server "3.2.1" :exclusions ['org.clojure/clojure]]
   truthy     ['vimclojure/server "3.2.1" :scope "test"]
+  truthy     ['vimclojure/server "3.2.1" :exclusions ['org.clojure/clojure] :scope "test"]
+  truthy     ['org.clojure/clojure]
+  truthy     ['org.clojure/clojure nil]
+  truthy     ['vimclojure/server :exclusions ['org.clojure/clojure]]
+  truthy     ['vimclojure/server nil :exclusions ['org.clojure/clojure]]
+  truthy     ['vimclojure/server :exclusions ['org.clojure/clojure] :scope "test"]
+  truthy     ['vimclojure/server nil :exclusions ['org.clojure/clojure] :scope "test"]
 
   ; though valid deps, these aren't dep-specs
   falsey     'typed
@@ -20,8 +27,6 @@
   falsey     '('org.clojure/clojure "1.3.0")
   ; empty
   falsey     []
-  ; missing version
-  falsey     ['foo]
   ; name is not a symbol
   falsey     [:foo "0.0"]
   ; version is not a string
@@ -38,6 +43,13 @@
   truthy     ['org.clojure/clojure "1.2.1"]
   truthy     ['vimclojure/server "3.2.1" :exclusions ['org.clojure/clojure]]
   truthy     ['vimclojure/server "3.2.1" :scope "test"]
+  truthy     ['vimclojure/server "3.2.1" :exclusions ['org.clojure/clojure] :scope "test"]
+  truthy     ['org.clojure/clojure]
+  truthy     ['org.clojure/clojure nil]
+  truthy     ['vimclojure/server :exclusions ['org.clojure/clojure]]
+  truthy     ['vimclojure/server nil :exclusions ['org.clojure/clojure]]
+  truthy     ['vimclojure/server :exclusions ['org.clojure/clojure] :scope "test"]
+  truthy     ['vimclojure/server nil :exclusions ['org.clojure/clojure] :scope "test"]
   truthy     'typed
   truthy     'org.clojure/clojure
 
@@ -45,8 +57,6 @@
   falsey     '('org.clojure/clojure "1.3.0")
   ; empty
   falsey     []
-  ; missing version
-  falsey     ['foo]
   ; name is not a symbol
   falsey     [:foo "0.0"]
   ; version is not a string


### PR DESCRIPTION
# What's changed?

As of [version 2.7.0](https://github.com/technomancy/leiningen/blob/master/NEWS.md#270--2016-08-24), Leiningen supports Maven's [managed dependencies](https://github.com/technomancy/leiningen/blob/master/doc/MANAGED_DEPS.md). When managed dependencies are used, version numbers in the `:dependencies` vector can now be `nil` or left off entirely.

I've rewritten `dep-spec?` to support the new syntax, with matching tests.

# Testing

`lein test leinjacker.deps-test` passes for me.

I need some help with running the other tests, however. Currently `lein test` crashes for me with this message:

```clojure
clojure.lang.Compiler$CompilerException:
  java.lang.IllegalStateException: Unable to find Leiningen 1 in the
    path as lein or lein 1. Please make sure it is installed and in your
    path under one of those names, or set LEIN1_CMD.,
  compiling:(leinjacker/test_multiple_lein_versions.clj:22:1)
```

I did try `lein upgrade 1.7.1` to install Leiningen v1, but that fails because the installer hardcoded the old repository URL for Clojure. So, if anybody else happens to have it installed, help with testing would be great :)

# Future compatibility

Leiningen 2.8 will support [dependency names as strings](https://github.com/technomancy/leiningen/blob/master/NEWS.md#280--). I can add support for that now too, get ahead of that issue.

# Version-specific behaviour?

While I've changed `dep-spec?` so it will always accept managed dependencies, they aren't actually allowed before Lein 2.7. And string dep names are only for Lein 2.8+. Should the behaviour of `dep-spec?` depend on the version of Leiningen you're running?