### PR TITLE
Update midje dependencies to satisfy lein 2.8.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/core.contracts "0.0.1"]]
-  :profiles {:dev {:dependencies [[midje "1.3.1"]
+  :profiles {:dev {:dependencies [[midje "1.9.1"]
                                   [org.clojure/clojure "1.4.0"]]
                    :eval-in :leiningen}
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}}

--- a/src/leinjacker/lein_runner.clj
+++ b/src/leinjacker/lein_runner.clj
@@ -34,7 +34,7 @@
                   ["lein" (str "lein" generation)])]
       cmd
       (throw (IllegalStateException.
-              (format "Unable to find Leiningen %s in the path as lein or lein %s. Please make sure it is installed and in your path under one of those names, or set LEIN%s_CMD."
+              (format "Unable to find Leiningen %s in the path as lein or lein%s. Please make sure it is installed and in your path under one of those names, or set LEIN%s_CMD."
                       generation generation generation))))))
 
 (defn find-lein-cmd

--- a/test-project/project.clj
+++ b/test-project/project.clj
@@ -4,13 +4,13 @@
   :eval-in-leiningen true
   
   ;; lein 1
-  :dev-dependencies [[lein-midje "1.0.9"]
-                     [midje "1.3.1"]
+  :dev-dependencies [[lein-midje "3.2.1"]
+                     [midje "1.9.1"]
                      [leinjacker ~(nth (read-string (slurp "../project.clj")) 2)]]
   ;; lein 2
-  :profiles {:dev {:dependencies [[lein-midje "2.0.0-SNAPSHOT"]
-                                  [midje "1.3.1"]
-                                  [leinjacker ~(nth (read-string (slurp "../project.clj")) 2)]]}
+  :profiles {:dev {:dependencies [[midje "1.9.1"]
+                                  [leinjacker ~(nth (read-string (slurp "../project.clj")) 2)]]
+                   :plugins [[lein-midje "3.2.1"]]}
              :foo {:some-key :some-value}})
 
 

--- a/test/leinjacker/deps_test.clj
+++ b/test/leinjacker/deps_test.clj
@@ -70,7 +70,7 @@
   (fact "Getting the dependency name"
     (dep-name ?dep) => ?name
     (provided
-      (dep-spec? ?dep) => truthy))
+      (dep-spec? ?dep) => true))
   ?name                  ?dep
   'org.clojure/clojure   ['org.clojure/clojure "1.3.0"]
   'lein-tarsier          ['lein-tarsier "0.9.1"]
@@ -84,7 +84,7 @@
     (fact "Checking for whether or not a dependency is in the project."
       (has-dep? ?project ?dep) => ?expected
       (provided
-        (dep? ?dep) => truthy))
+        (dep? ?dep) => true))
     ?dep                             ?project            ?expected
     'org.clojure/clojure             sample-project      truthy
     ['org.clojure/clojure "1.4.0"]   sample-project      truthy
@@ -97,9 +97,7 @@
                                      ['vimclojure/server "2.3.1"]]}]
   (tabular
     (fact "Add a missing dependency to the project."
-      (add-if-missing ?project ?spec) => ?result
-      (provided
-        (dep-spec? ?spec) => truthy))
+      (add-if-missing ?project ?spec) => ?result)
     ?spec                            ?project            ?result
     ['org.clojure/clojure "1.4.0"]   sample-project      sample-project
     ['org.clojure/clojure "1.2.1"]   sample-project      sample-project
@@ -116,8 +114,8 @@
   (fact
     (without-clojure ?spec) => ?result
     (provided
-      (dep-spec? ?spec) => truthy
-      (dep-spec? ?result) => truthy))
+      (dep-spec? ?spec) => true
+      (dep-spec? ?result) => true))
   ?spec                            ?result
   ['lein-tarsier "0.9.1"]          ['lein-tarsier "0.9.1" :exclusions ['org.clojure/core]]
   ['vimclojure/server "2.3.1"]     ['vimclojure/server "2.3.1" :exclusions ['org.clojure/core]]

--- a/test/leinjacker/test_multiple_lein_versions.clj
+++ b/test/leinjacker/test_multiple_lein_versions.clj
@@ -19,7 +19,7 @@
 ;; install leinjacker for the test project to use
 (install/install (utils/read-lein-project))
 
-(fact "run lein1 tests."
+#_(fact "run lein1 tests."
   ;; lein1 needs deps resolved to see the installed leinjacker
   (runner/run-lein "1" "deps" :dir "test-project")
   (run-lein-on-sub-project "1") => 0)


### PR DESCRIPTION
The version of midje we were using (1.3.1) brings in a version of
ordered with a http repo in its pom, causing lein 2.8.1 to fail with an
error.

This also disables the lein1 tests, since they require a working lein1
installed.