### PR TITLE
Update core.contracts to fix Clojure 1.10 compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/core.contracts "0.0.1"]]
+  :dependencies [[org.clojure/core.contracts "0.0.6"]]
   :profiles {:dev {:dependencies [[midje "1.3.1"]
                                   [org.clojure/clojure "1.4.0"]]
                    :eval-in :leiningen}


### PR DESCRIPTION
The current version of Leinjacker doesn't work with Clojure 1.10 because the `core.contracts` dep depends on an out-of-date version of `core.unify` that doesn't work with Clojure 1.10. Fixed by updating `core.contracts` dep.

Fixes #16